### PR TITLE
Changed ARM and YAML required to use new Find Employment Schemes name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
 - group: RELEASE Management Resources
 - group: RELEASE das-find-employment-schemes
 - name: Deploy
-  value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))]
+  value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'), eq(variables['Build.Reason'], 'PullRequest'))]
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,13 +6,15 @@ trigger:
 
 variables:
 - name: SolutionBaseName
-  value: SFA.DAS.Employer.FrontDoor.Web
+  value: SFA.DAS.FindEmploymentSchemes.Web
 - name: BuildConfiguration
   value: release
 - name: BuildPlatform
   value: any cpu
 - group: RELEASE Management Resources
-- group: RELEASE das-employers-front-door
+- group: RELEASE das-find-employment-schemes
+- name: Deploy
+  value: $[or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'Manual'))]
 
 resources:
   repositories:
@@ -44,6 +46,7 @@ stages:
 - stage: Deploy_AT
   dependsOn: Build
   displayName: Deploy to AT
+  condition: and(succeeded(), eq(variables.Deploy, 'true'))
   variables:
   - group: DevTest Management Resources
   - group: AT DevTest Shared Resources

--- a/azure/template.json
+++ b/azure/template.json
@@ -64,8 +64,8 @@
         "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
         "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
-        "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
-        "configNames": "SFA.DAS.EmployersFrontDoor.Web"
+        "appServiceName": "[concat(variables('resourceNamePrefix'), 'ui-as')]",
+        "configNames": "SFA.DAS.FindEmploymentSchemes.Web"
     },
     "resources": [
         {
@@ -78,7 +78,7 @@
         },
         {
             "apiVersion": "2021-04-01",
-            "name": "das-employer-front-door-app-service-certificate",
+            "name": "das-find-employment-schemes-app-service-certificate",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[parameters('sharedEnvResourceGroup')]",
             "properties": {
@@ -105,7 +105,7 @@
         },
         {
             "apiVersion": "2021-04-01",
-            "name": "das-employer-front-door-application-insights",
+            "name": "das-find-employment-schemes-application-insights",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
@@ -129,7 +129,7 @@
         },
         {
             "apiVersion": "2021-04-01",
-            "name": "das-employer-front-door-app-service",
+            "name": "das-find-employment-schemes-app-service",
             "type": "Microsoft.Resources/deployments",
             "resourceGroup": "[variables('resourceGroupName')]",
             "properties": {
@@ -172,7 +172,7 @@
                                 },
                                 {
                                     "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                                    "value": "[reference('das-employer-front-door-application-insights').outputs.InstrumentationKey.value]"
+                                    "value": "[reference('das-find-employment-schemes-application-insights').outputs.InstrumentationKey.value]"
                                 },
                                 {
                                     "name": "LoggingRedisConnectionString",
@@ -193,7 +193,7 @@
                         "value": "[parameters('customHostname')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[reference('das-employer-front-door-app-service-certificate').outputs.certificateThumbprint.value]"
+                        "value": "[reference('das-find-employment-schemes-app-service-certificate').outputs.certificateThumbprint.value]"
                     },
                     "ipSecurityRestrictions": {
                         "value": "[parameters('frontEndAccessRestrictions')]"

--- a/pipeline-templates/job/code-build.yml
+++ b/pipeline-templates/job/code-build.yml
@@ -13,9 +13,6 @@ jobs:
   - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
 
   - template: azure-pipelines-templates/build/step/app-build.yml@das-platform-building-blocks
-    parameters:
-      SonarCloud: true
-      SonarCloudProjectKey: SkillsFundingAgency_das-employers-front-door
 
   - template: azure-pipelines-templates/build/step/dependency-check.yml@das-platform-building-blocks
 
@@ -41,4 +38,4 @@ jobs:
     displayName: Publish Artifact drop
     inputs:
       targetPath: $(build.artifactstagingdirectory)/publish
-      artifactName: EmployersFrontDoor
+      artifactName: FindEmploymentSchemes

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -23,8 +23,8 @@ jobs:
             SubscriptionId: $(SubscriptionId)
             Location: $(ResourceGroupLocation)
             Environment: ${{ parameters.Environment }}
-            TemplatePath: $(Pipeline.Workspace)/EmployersFrontDoor/azure/template.json
-            ParametersPath: $(Pipeline.Workspace)/EmployersFrontDoor/azure/template.parameters.json
+            TemplatePath: $(Pipeline.Workspace)/FindEmploymentSchemes/azure/template.json
+            ParametersPath: $(Pipeline.Workspace)/FindEmploymentSchemes/azure/template.parameters.json
             IsMultiRepoCheckout: true
             TemplateSecrets:
               LoggingRedisConnectionString: $(LoggingRedisConnectionString)
@@ -32,11 +32,11 @@ jobs:
         - template: azure-pipelines-templates/deploy/step/generate-config.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
-            SourcePath: $(Pipeline.Workspace)/das-employer-config/Configuration/das-employers-front-door
+            SourcePath: $(Pipeline.Workspace)/das-employer-config/Configuration/das-find-employment-schemes
             TargetFileName: '*.schema.json'
             TableName: Configuration
         - template: azure-pipelines-templates/deploy/step/app-deploy.yml@das-platform-building-blocks
           parameters:
             ServiceConnection: ${{ parameters.ServiceConnection }}
             AppServiceName: $(AppServiceName)
-            DeploymentPackagePath: $(Pipeline.Workspace)/EmployersFrontDoor/SFA.DAS.Employer.FrontDoor.Web.zip
+            DeploymentPackagePath: $(Pipeline.Workspace)/FindEmploymentSchemes/SFA.DAS.FindEmploymentSchemes.Web.zip


### PR DESCRIPTION
Changed ARM and YAML required to use new Find Employment Schemes name and also removed SonarCloud Set up and created condition for only deploying to AT when main or manually run