### PR TITLE
Productionise Javascript filtering

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator/Program.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator/Program.cs
@@ -14,9 +14,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator
 {
     internal class Program
     {
-        private const string payFilterPrefix = "pay";
-        private const string motivationsFilterPrefix = "motivations";
-        private const string schemeLengthFilterPrefix = "scheme-length";
+        private const string PayFilterPrefix = "pay";
+        private const string MotivationsFilterPrefix = "motivations";
+        private const string SchemeLengthFilterPrefix = "scheme-length";
 
         static async Task Main(string[] args)
         {
@@ -32,9 +32,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator
 
             await GenerateSchemesContent(client, htmlRenderer);
 
-            await GenerateFilterContent<MotivationsFilter>(client, "motivationsFilter", motivationsFilterPrefix);
-            await GenerateFilterContent<PayFilter>(client, "payFilter", payFilterPrefix);
-            await GenerateFilterContent<SchemeLengthFilter>(client, "schemeLengthFilter", schemeLengthFilterPrefix);
+            await GenerateFilterContent<MotivationsFilter>(client, "motivationsFilter", MotivationsFilterPrefix);
+            await GenerateFilterContent<PayFilter>(client, "payFilter", PayFilterPrefix);
+            await GenerateFilterContent<SchemeLengthFilter>(client, "schemeLengthFilter", SchemeLengthFilterPrefix);
 
             Console.WriteLine(Closing());
         }
@@ -74,9 +74,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator
                 Console.WriteLine($"\"{scheme.Url}\", {scheme.Size},");
 
                 Console.Write("new string[] {");
-                Console.Write(GenerateFilterIds(scheme.PayFilterAspects, payFilterPrefix));
-                Console.Write(GenerateFilterIds(scheme.MotivationsFilterAspects, motivationsFilterPrefix));
-                Console.Write(GenerateFilterIds(scheme.SchemeLengthFilterAspects, schemeLengthFilterPrefix));
+                Console.Write(GenerateFilterIds(scheme.PayFilterAspects, PayFilterPrefix));
+                Console.Write(GenerateFilterIds(scheme.MotivationsFilterAspects, MotivationsFilterPrefix));
+                Console.Write(GenerateFilterIds(scheme.SchemeLengthFilterAspects, SchemeLengthFilterPrefix));
                 Console.WriteLine("},");
 
                 Console.WriteLine($"{await AsHtmlString(scheme.DetailsPageOverride, htmlRenderer)},");
@@ -119,7 +119,7 @@ namespace SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator
             var filterIds = new StringBuilder();
             foreach (var payFilter in filters)
             {
-                filterIds.Append($"\"{filterPrefix}-{Slugify(payFilter.Name)}\", ");
+                filterIds.Append($"\"{filterPrefix}--{Slugify(payFilter.Name)}\", ");
             }
 
             return filterIds.ToString();
@@ -142,7 +142,7 @@ namespace SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator
 
             foreach (T filter in orderedFilters)
             {
-                Console.WriteLine($"new {typeof(T).Name}(\"{filterPrefix}-{Slugify(filter.Name)}\",");
+                Console.WriteLine($"new {typeof(T).Name}(\"{filterPrefix}--{Slugify(filter.Name)}\",");
                 Console.WriteLine($"\"{filter.Description}\"");
                 Console.WriteLine("),");
             }

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Content/SchemesContent.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Content/SchemesContent.cs
@@ -31,8 +31,8 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "apprenticeships", 403000,
                 new string[]
                 {
-                    "pay-minimum-wage", "motivations-full-time-role", "motivations-diversity-or-responsibility",
-                    "scheme-length-4-months-to-12-months", "scheme-length-a-year-or-more",
+                    "pay--minimum-wage", "motivations--full-time-role", "motivations--diversity-or-responsibility",
+                    "scheme-length--4-months-to-12-months", "scheme-length--a-year-or-more",
                 },
                 null,
                 new HtmlString(
@@ -58,8 +58,8 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "t-levels-industry-placements", 72000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -87,8 +87,8 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "sector-based-work-academy-programme-swap", 70000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role", "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -114,9 +114,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "skills-bootcamps", 68000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-4-months-to-12-months",
-                    "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role",
+                    "scheme-length--4-months-to-12-months", "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -142,9 +142,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "traineeships", 43000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-4-months-to-12-months",
-                    "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role",
+                    "scheme-length--4-months-to-12-months", "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -172,8 +172,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "supported-internships-for-learners-with-an-education-health-and-care-plan", 20000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-4-months-to-12-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role",
+                    "scheme-length--4-months-to-12-months",
                 },
                 null,
                 new HtmlString(
@@ -200,9 +201,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "care-leaver-covenant", 2000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-a-year-or-more",
-                    "scheme-length-4-months-to-12-months", "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role", "scheme-length--a-year-or-more",
+                    "scheme-length--4-months-to-12-months", "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -227,9 +228,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "employing-prisoners-and-prison-leavers", 1000,
                 new string[]
                 {
-                    "pay-minimum-wage", "motivations-diversity-or-responsibility", "motivations-full-time-role",
-                    "scheme-length-a-year-or-more", "scheme-length-4-months-to-12-months",
-                    "scheme-length-up-to-4-months",
+                    "pay--minimum-wage", "motivations--diversity-or-responsibility", "motivations--full-time-role",
+                    "scheme-length--a-year-or-more", "scheme-length--4-months-to-12-months",
+                    "scheme-length--up-to-4-months",
                 },
                 null,
                 new HtmlString(
@@ -254,7 +255,7 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                     @"<p>Developed by employers to upskill existing employees, provide a different recruitment pool to hire new talent and help your company succeed</p>"),
                 new HtmlString(@"<p>1 to 2 years</p>"),
                 "higher-technical-qualifications", -500,
-                new string[] {"pay-minimum-wage", "motivations-full-time-role", "scheme-length-a-year-or-more",},
+                new string[] {"pay--minimum-wage", "motivations--full-time-role", "scheme-length--a-year-or-more",},
                 null,
                 new HtmlString(
                     @"<p>Higher Technical Qualifications (HTQs) are a high-quality addition to technical training routes, alongside apprenticeships, traineeships and degrees.</p><p>They are:</p><ul class =""govuk-list govuk-list--bullet""><li>new and existing Level 4 and 5 qualifications (such as Higher National Diplomas, Foundation Degrees, Diploma Higher Education)</li><li>approved by the Institute for Apprenticeships and Technical Education, against employer-led occupational standards</li></ul><p>The first Digital HTQs will be available for teaching from 2022, leading to higher-level occupations like Network Engineer, Software Developer and Data Analyst.</p><p>Health and Science and Construction qualifications will be available for teaching from 2023, with a full roll-out of further industrial sectors over a four-year period.</p>"),
@@ -279,9 +280,9 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
                 "training-outside-of-employment", -1000,
                 new string[]
                 {
-                    "pay-unpaid", "pay-minimum-wage", "motivations-diversity-or-responsibility",
-                    "motivations-unpaid-placement", "motivations-full-time-role", "scheme-length-a-year-or-more",
-                    "scheme-length-4-months-to-12-months", "scheme-length-up-to-4-months",
+                    "pay--unpaid", "pay--minimum-wage", "motivations--diversity-or-responsibility",
+                    "motivations--unpaid-placement", "motivations--full-time-role", "scheme-length--a-year-or-more",
+                    "scheme-length--4-months-to-12-months", "scheme-length--up-to-4-months",
                 },
                 new HtmlString(
                     @"<p>Career advice, free level 3 qualifications, and financial support for level 4 and 5 qualifications are all available through Government initiatives for your workforce.</p><h2 class=""govuk-heading-l"">Free qualifications for adults</h2><p><a href=""https://www.gov.uk/guidance/free-courses-for-jobs"" title="""" class=""govuk-link"">Free level 3 qualifications</a> are government-funded courses for any adult aged 19 and over, who are looking to achieve their first full level 3 qualification or earning below national minimum wage.</p><p>A full level 3 qualification is equivalent to an advanced technical certificate, diploma, or A levels.</p><p>Without needing to fund the training yourself, they help you:</p><ul class =""govuk-list govuk-list--bullet""><li>develop the talent pool in your business</li><li>progress your current employees into higher skilled roles</li></ul><p>The <a href=""https://www.gov.uk/guidance/free-courses-for-jobs"" title="""" class=""govuk-link"">Free Courses for jobs</a> offer and the qualification list has been developed with industry, and will be regularly reviewed. </p><h3 class=""govuk-heading-m"">Benefits of free level 3 qualifications</h3><p>Read the <a href=""https://learning.linkedin.com/content/dam/me/business/en-us/amp/learning-solutions/images/workplace-learning-report-2019/pdf/workplace-learning-report-2019.pdf"" title="""" class=""govuk-link"">LinkedIn Workplace Learning</a> report 2019 for information on developing a loyal and talented workforce.</p><div class=""cx-cta-box""><p>Offer free qualifications to adults</p><p>Upskill your workforce by helping your employees <a href=""https://www.gov.uk/government/publications/find-a-free-level-3-qualification"" title="""" class=""govuk-link"">find a free level 3 qualification</a>.</p></div><h2 class=""govuk-heading-l"">National Careers Service</h2><p>The National Careers Service can help you:</p><ul class =""govuk-list govuk-list--bullet""><li>explore work and skills opportunities for your workforce including those offered as part of the skills recovery package.</li><li>carry out skills needs analysis for your business to understand gaps and find solutions.</li><li>find skilled people to fill current vacancies in your organisation.</li></ul><h3 class=""govuk-heading-m"">Employer costs</h3><p>The National Careers Service is free to use.</p><h3 class=""govuk-heading-m"">Benefits of National Careers Service</h3><p>The National Careers Service can help you:</p><ul class =""govuk-list govuk-list--bullet""><li>futureproof your business for the future labour market</li><li>help to develop your current workforce and supplement with talented individuals who have the skills you need</li><li>increase your resilience and productivity</li><li>take part in national virtual jobs fairs</li></ul><div class=""cx-cta-box""><p>Use the National Careers Service to support your workforce</p><p>Find out more about the <a href=""https://nationalcareers.service.gov.uk/"" title="""" class=""govuk-link"">National Careers Service and how to contact them</a>.</p></div><p></p>"),
@@ -298,13 +299,13 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
         public static readonly IEnumerable<MotivationsFilter> MotivationsFilters = new MotivationsFilter[]
         {
 
-            new MotivationsFilter("motivations-full-time-role",
+            new MotivationsFilter("motivations--full-time-role",
                 "help train someone up into a full-time role"
             ),
-            new MotivationsFilter("motivations-unpaid-placement",
+            new MotivationsFilter("motivations--unpaid-placement",
                 "offer someone an unpaid work placement opportunity"
             ),
-            new MotivationsFilter("motivations-diversity-or-responsibility",
+            new MotivationsFilter("motivations--diversity-or-responsibility",
                 "diversify our workforce or for corporate and social responsibility"
             ),
         };
@@ -312,10 +313,10 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
         public static readonly IEnumerable<PayFilter> PayFilters = new PayFilter[]
         {
 
-            new PayFilter("pay-minimum-wage",
+            new PayFilter("pay--minimum-wage",
                 "at least national minimum wage"
             ),
-            new PayFilter("pay-unpaid",
+            new PayFilter("pay--unpaid",
                 "unpaid placements"
             ),
         };
@@ -323,13 +324,13 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Content
         public static readonly IEnumerable<SchemeLengthFilter> SchemeLengthFilters = new SchemeLengthFilter[]
         {
 
-            new SchemeLengthFilter("scheme-length-up-to-4-months",
+            new SchemeLengthFilter("scheme-length--up-to-4-months",
                 "Up to 4 months"
             ),
-            new SchemeLengthFilter("scheme-length-4-months-to-12-months",
+            new SchemeLengthFilter("scheme-length--4-months-to-12-months",
                 "4 months to 12 months"
             ),
-            new SchemeLengthFilter("scheme-length-a-year-or-more",
+            new SchemeLengthFilter("scheme-length--a-year-or-more",
                 "A year or more"
             ),
         };

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Controllers/SchemesController.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Controllers/SchemesController.cs
@@ -1,14 +1,9 @@
-
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.FindEmploymentSchemes.Web.Content;
 using SFA.DAS.FindEmploymentSchemes.Web.Models;
 using SFA.DAS.FindEmploymentSchemes.Web.Services;
 using SFA.DAS.FindEmploymentSchemes.Web.ViewModels;
-
 
 namespace SFA.DAS.FindEmploymentSchemes.Web.Controllers
 {
@@ -17,13 +12,13 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Controllers
         private readonly ILogger<SchemesController> _logger;
         private readonly IFilterService _filterService;
 
-        private readonly HomeModel? _homeModel = null;
-
+        private readonly HomeModel _homeModel;
 
         public SchemesController(ILogger<SchemesController> logger, IFilterService filterService)
         {
             _logger = logger;
             _filterService = filterService;
+            //todo: can we have a static version of this?
             _homeModel = new HomeModel(SchemesContent.Schemes, _filterService.FilterGroupModels());
         }
 

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Models/Interfaces/IFilterAspect.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Models/Interfaces/IFilterAspect.cs
@@ -6,5 +6,3 @@
         public string Description { get; set; }
     }
 }
-
-//todo: class will create filterid from guaranteed unique Id (replace spaces)

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Notes.md
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Notes.md
@@ -1,18 +1,5 @@
 ﻿#todo
 
-add id's to elements for automation tests
-
 skipping heading levels is discouraged, but shouldn't fail WCAG
 https://www.tpgi.com/heading-off-confusion-when-do-headings-fail-wcag/
 need to check if there is a need for -l, if not exclude it from the hierarchy
-
-partial for short scheme - as will be reused by details page
-
-#Pipeline Variables
-
-CdnBaseUrl
-
-das-$(ResourceEnvironmentName)-frnt-end.azureedge.net
-
-Release
-

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Services/FilterService.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Services/FilterService.cs
@@ -1,31 +1,27 @@
-﻿
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
 using SFA.DAS.FindEmploymentSchemes.Web.Content;
 using SFA.DAS.FindEmploymentSchemes.Web.Models;
 using SFA.DAS.FindEmploymentSchemes.Web.ViewModels;
-
 
 namespace SFA.DAS.FindEmploymentSchemes.Web.Services
 {
     public class FilterService : IFilterService
     {
-        private const string MOTIVATION_NAME = "motivations";
-        private const string MOTIVATION_DESCRIPTION = "I want to";
-        private const string SCHEME_LENGTH_NAME = "schemeLength";
-        private const string SCHEME_LENGTH_DESCRIPTION = "Length of scheme?";
-        private const string PAY_NAME = "pay";
-        private const string PAY_DESCRIPTION = "I can offer";
+        private const string MotivationName = "motivations";
+        private const string MotivationDescription = "I want to";
+        private const string SchemeLengthName = "schemeLength";
+        private const string SchemeLengthDescription = "Length of scheme?";
+        private const string PayName = "pay";
+        private const string PayDescription = "I can offer";
 
         public FilterGroupModel[] FilterGroupModels()
         {
-            return new FilterGroupModel[] {
-                new FilterGroupModel(MOTIVATION_NAME, MOTIVATION_DESCRIPTION, SchemesContent.MotivationsFilters),
-                new FilterGroupModel(SCHEME_LENGTH_NAME, SCHEME_LENGTH_DESCRIPTION, SchemesContent.SchemeLengthFilters),
-                new FilterGroupModel(PAY_NAME, PAY_DESCRIPTION, SchemesContent.PayFilters)
+            return new[] {
+                new FilterGroupModel(MotivationName, MotivationDescription, SchemesContent.MotivationsFilters),
+                new FilterGroupModel(SchemeLengthName, SchemeLengthDescription, SchemesContent.SchemeLengthFilters),
+                new FilterGroupModel(PayName, PayDescription, SchemesContent.PayFilters)
             };
         }
 
@@ -62,11 +58,11 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Services
                 filteredSchemes = SchemesContent.Schemes;
 
             List<FilterGroupModel> filterGroupModels = new List<FilterGroupModel> { };
-            filterGroupModels.Add(new FilterGroupModel(MOTIVATION_NAME, MOTIVATION_DESCRIPTION,
+            filterGroupModels.Add(new FilterGroupModel(MotivationName, MotivationDescription,
                                   SchemesContent.MotivationsFilters.Select(x => new MotivationsFilter(x.Id, x.Description, filters.motivations.Contains(x.Id)))));
-            filterGroupModels.Add(new FilterGroupModel(SCHEME_LENGTH_NAME, SCHEME_LENGTH_DESCRIPTION,
+            filterGroupModels.Add(new FilterGroupModel(SchemeLengthName, SchemeLengthDescription,
                                   SchemesContent.SchemeLengthFilters.Select(x => new SchemeLengthFilter(x.Id, x.Description, filters.schemeLength.Contains(x.Id)))));
-            filterGroupModels.Add(new FilterGroupModel(PAY_NAME, PAY_DESCRIPTION,
+            filterGroupModels.Add(new FilterGroupModel(PayName, PayDescription,
                                   SchemesContent.PayFilters.Select(x => new PayFilter(x.Id, x.Description, filters.pay.Contains(x.Id)))));
 
             return new HomeModel(filteredSchemes, filterGroupModels);

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Services/IFilterService.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Services/IFilterService.cs
@@ -1,11 +1,7 @@
-﻿
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Threading.Tasks;
 using SFA.DAS.FindEmploymentSchemes.Web.Models;
 using SFA.DAS.FindEmploymentSchemes.Web.ViewModels;
-
 
 namespace SFA.DAS.FindEmploymentSchemes.Web.Services
 {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
@@ -16,7 +16,7 @@
             </div>
             <div class="das-filter__body" id="scheme-filter-options">
                 <div id="number-of-schemes-box">
-                    <h3 id="number-of-schemes-heading" class="govuk-heading-s">Number of Schemes: <span id="number-of-schemes"></span></h3>
+                    <h3 id="number-of-schemes-heading" class="govuk-heading-s">Number of Schemes: <span id="number-of-schemes">@Model.Schemes.Count()</span></h3>
                 </div>
                 <form action="#" method="post">
                     <div class="govuk-button-group">

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
@@ -22,7 +22,7 @@
                     <div class="govuk-button-group">
                         <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 das-js-hide">Apply filters</button>
                     </div>
-                    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible das-js-hide">
                     @foreach (var filterGroupModel in Model.FilterGroupModels)
                     {
                         @await Html.PartialAsync("_FilterGroupPartial", filterGroupModel)

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
@@ -47,6 +47,12 @@
 
 <script>
     document.addEventListener("DOMContentLoaded", function() {
-        initFiltering();
+        if (window.document.documentMode) {
+            // if the user agent is ie, fall back to non-js based filtering
+            $('.das-js-hide').show();
+        }
+        else {
+            initFiltering();
+        }
     });
 </script>

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -113,12 +113,22 @@
             </div>
          </div>
       </header>
-      <div class="govuk-width-container">
-        @RenderSection("BreadCrumbs", required: false)
-         <main class="govuk-main-wrapper" id="main-content" role="main">
-            @RenderBody()
-         </main>
-      </div>
+   <div class="govuk-width-container">
+       <div class="govuk-phase-banner">
+           <p class="govuk-phase-banner__content">
+               <strong class="govuk-tag govuk-phase-banner__content__tag">
+                   beta
+               </strong>
+               <span class="govuk-phase-banner__text">
+                   This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+               </span>
+           </p>
+       </div>
+       @RenderSection("BreadCrumbs", required: false)
+       <main class="govuk-main-wrapper" id="main-content" role="main">
+           @RenderBody()
+       </main>
+   </div>
       <footer class="govuk-footer" role="contentinfo">
          <div class="govuk-width-container ">
             <div class="govuk-footer__meta">

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -120,7 +120,7 @@
                    beta
                </strong>
                <span class="govuk-phase-banner__text">
-                   This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+                   This is a new service – your <a class="govuk-link" href="https://forms.office.com/r/JChsG8Ducg">feedback</a> will help us to improve it.
                </span>
            </p>
        </div>

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_SchemePartial.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_SchemePartial.cshtml
@@ -2,7 +2,6 @@
 
 <section data-scheme @{ RenderFilterIds(Model.FilterAspects); }>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    @*todo: best form? accessibility, route, helper? etc.*@
     <h2 class="govuk-heading-m govuk-!-margin-bottom-3"><a asp-route="schemes" asp-route-schemeUrl="@Model.Url" class="govuk-link">@Model.Name</a></h2>
     <p class="govuk-body">@Model.ShortDescription</p>
     <div class="govuk-grid-row">

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/css/site.css
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/css/site.css
@@ -65,7 +65,7 @@
 #number-of-schemes-box {
     background: #f3f2f1;
     padding: 15px;
-    margin-bottom: 25px;
+    margin-bottom: 15px;
 }
 
 #number-of-schemes-heading {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/app.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/app.js
@@ -9,6 +9,10 @@ function nodeListForEach(nodes, callback) {
 
 var showHideElements = document.querySelectorAll('[data-module="app-show-hide"]')
 
+var showHideEls = [];
+
 nodeListForEach(showHideElements, function (showHideElement) {
-    new ShowHideElement(showHideElement).init()
+    var showHideEl = new ShowHideElement(showHideElement);
+    showHideEl.init();
+    showHideEls.push(showHideEl);
 })

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/app.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/app.js
@@ -9,10 +9,13 @@ function nodeListForEach(nodes, callback) {
 
 var showHideElements = document.querySelectorAll('[data-module="app-show-hide"]')
 
-var showHideEls = [];
+var showHideEls = {};
 
 nodeListForEach(showHideElements, function (showHideElement) {
     var showHideEl = new ShowHideElement(showHideElement);
     showHideEl.init();
-    showHideEls.push(showHideEl);
+
+    if (showHideElement.hasAttribute('id')) {
+        showHideEls[showHideElement.id] = showHideEl;
+    }
 })

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -13,19 +13,15 @@ function initFiltering(options) {
     // we need to ensure that when the page is displayed:
     //  * from a bookmark/copy & pasted link
     //  * traversing through history
-    // that the correct filters are ticked and the schemes are filtered correctly
+    // that the correct filters are ticked, the schemes are filtered correctly, and the filter panel is displayed if any filters are selected
     const filters = updateFiltersFromFragmentAndShowResults();
     initEvents();
 
     // if the scheme's are filtered, then ensure the filter panel is displayed
     if (!NoFilters(filters)) {
         $('#scheme-filter').removeClass('app-show-hide__section--show');
-        //todo: store by id - we don't want to toggle all
-        nodeListForEach(showHideEls,
-            function (showHideElement) {
-                //warning: calls preventDefault()
-                showHideElement.showHideTarget(showHideElement);
-            });
+        const schemeFilterShowHide = showHideEls['scheme-filter'];
+        schemeFilterShowHide.showHideTarget(schemeFilterShowHide);
     }
 }
 

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -11,15 +11,11 @@ const filterParamName = 'filter';
 
 function initFiltering(options) {
     // we need to ensure that when the page is displayed:
-    //  * from a bookmark
+    //  * from a bookmark/copy & pasted link
     //  * traversing through history
     // that the correct filters are ticked and the schemes are filtered correctly
-    updateFiltersFromFragmentAndShowResults();
+    const filters = updateFiltersFromFragmentAndShowResults();
     initEvents();
-
-    //todo: return filters from above
-    const hashParams = getHashParams();
-    const filters = getFilters(hashParams);
 
     // if the scheme's are filtered, then ensure the filter panel is displayed
     if (!NoFilters(filters)) {
@@ -40,6 +36,8 @@ function updateFiltersFromFragmentAndShowResults() {
     updateCheckboxesFromFragment(filters);
     showHideSchemes(filters);
     updateNumberOfSchemes();
+
+    return filters;
 }
 
 function NoFilters(filters) {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -3,8 +3,6 @@
 
 /*browsers we need to support: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices*/
 
-/*todo: we'll check for IE and let them use the non-javascript enhanced version*/
-
 /*todo:use modules, remove globals! ts?*/
 
 /*can we safely change query params, or will we need qp/hash dual scheme?*/
@@ -101,11 +99,7 @@ function updateFragmentFromCheckboxes() {
     setHashParams(hashParams, true);
 }
 
-//function getHashParams() {
-//    return new URLSearchParams(window.location.hash.substr(1)); // skip the first char (#)
-//}
-
- http://stackoverflow.com/questions/4197591/parsing-url-hash-fragment-identifier-with-javascript
+// http://stackoverflow.com/questions/4197591/parsing-url-hash-fragment-identifier-with-javascript
 function getHashParams() {
 
     var hashParams = {};

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -93,7 +93,6 @@ function initEvents() {
     });
 
     $(filterSchemesCheckboxSelector).click(function () {
-        //todo: sync checkbox?
         updateFragmentFromCheckboxes();
     });
 
@@ -115,9 +114,7 @@ function updateFragmentFromCheckboxes() {
         var filterId;
         if ($this.prop('checked')) {
             filterId = $this.val();
-            //if ($.inArray(filterId, newFilter) === -1) {
-                newFilter.push(filterId);
-            //}
+            newFilter.push(filterId);
         }
     });
 
@@ -152,8 +149,6 @@ function setHashParams(hashParams, updateResults) {
         fragment += key + '=' + value + '&';
     });
 
-    //todo: only need to update if changed
-    //todo: check fragment.length === 0
     window.location.hash = fragment.substr(0, fragment.length - 1);
 }
 

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -61,7 +61,6 @@ function showHideSchemes(filters) {
         return;
     }
 
-    //todo: check in ie
     const filterGroups = filters.reduce((result, filter) => {
             const filterGroup = filter.substr(0, filter.indexOf('--'));
 

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -63,13 +63,32 @@ function showHideSchemes(filters) {
         return;
     }
 
-    const showSchemeSelector = filters.map(function (param) {
-        return '[data-filter-' + param + ']';
-    }).join('');
+    //todo: check in ie
+    const filterGroups = filters.reduce((result, filter) => {
+            const filterGroup = filter.substr(0, filter.indexOf('--'));
 
-    $('[data-scheme]').hide().filter(showSchemeSelector).show();
+            result[filterGroup] = result[filterGroup] || [];
+
+            result[filterGroup].push(filter);
+
+            return result;
+        },
+        {});
+
+    var schemes = $('[data-scheme]').hide();
+
+    // we _could_ just create a single selector rather than calling filter repeatedly
+    Object.keys(filterGroups).forEach(function (filterGroupName) {
+
+        const showSchemeSelector = filterGroups[filterGroupName].map(function (filter) {
+            return '[data-filter-' + filter + ']';
+        }).join(',');
+
+        schemes = schemes.filter(showSchemeSelector);
+    });
+
+    schemes.show();
 }
-
 
 function initEvents() {
     window.addEventListener('hashchange', function () {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -3,8 +3,6 @@
 
 /*browsers we need to support: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices*/
 
-/*can we safely change query params, or will we need qp/hash dual scheme?*/
-
 const filterSchemesCheckboxSelector = '#scheme-filter-options :checkbox';
 const numberOfSchemesSelector = '#number-of-schemes';
 const filterParamName = 'filter';

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -10,8 +10,27 @@ const numberOfSchemesSelector = '#number-of-schemes';
 const filterParamName = 'filter';
 
 function initFiltering(options) {
+    // we need to ensure that when the page is displayed:
+    //  * from a bookmark
+    //  * traversing through history
+    // that the correct filters are ticked and the schemes are filtered correctly
     updateFiltersFromFragmentAndShowResults();
     initEvents();
+
+    //todo: return filters from above
+    const hashParams = getHashParams();
+    const filters = getFilters(hashParams);
+
+    // if the scheme's are filtered, then ensure the filter panel is displayed
+    if (!NoFilters(filters)) {
+        $('#scheme-filter').removeClass('app-show-hide__section--show');
+        //todo: store by id - we don't want to toggle all
+        nodeListForEach(showHideEls,
+            function (showHideElement) {
+                //warning: calls preventDefault()
+                showHideElement.showHideTarget(showHideElement);
+            });
+    }
 }
 
 function updateFiltersFromFragmentAndShowResults() {
@@ -21,6 +40,10 @@ function updateFiltersFromFragmentAndShowResults() {
     updateCheckboxesFromFragment(filters);
     showHideSchemes(filters);
     updateNumberOfSchemes();
+}
+
+function NoFilters(filters) {
+    return (filters.length === 0 || filters.length === 1 && filters[0] === '');
 }
 
 function updateCheckboxesFromFragment(filters) {
@@ -41,7 +64,7 @@ function getFilters(hashParams) {
 
 function showHideSchemes(filters) {
 
-    if (filters.length === 0 || filters.length === 1 && filters[0] === '') {
+    if (NoFilters(filters)) {
         $('[data-scheme]').show();
         return;
     }

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/wwwroot/js/filter.js
@@ -3,8 +3,6 @@
 
 /*browsers we need to support: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices*/
 
-/*todo:use modules, remove globals! ts?*/
-
 /*can we safely change query params, or will we need qp/hash dual scheme?*/
 
 const filterSchemesCheckboxSelector = '#scheme-filter-options :checkbox';


### PR DESCRIPTION
Also
* add alpha banner
* show scheme count when js disabled

Javascript filtering tested on:
* Windows Edge
* WIndows Chrome
* Windows Firefox
* Windows Opera
* iPad Chrome
* iPad Safari
* Android Chrome
* MacOS Safari

Internet Explorer falls back to the non Javascript filtering mechanism (tested in Edge's IE mode).