### PR TITLE
Upgrade nuget packages to latest version with same major version number

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator.csproj
+++ b/src/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator/SFA.DAS.FindEmploymentSchemes.Contentful.ContentCodeGenerator.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="contentful.csharp" Version="6.0.16" />
+    <PackageReference Include="contentful.csharp" Version="6.0.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.FindEmploymentSchemes.Contentful/SFA.DAS.FindEmploymentSchemes.Contentful.csproj
+++ b/src/SFA.DAS.FindEmploymentSchemes.Contentful/SFA.DAS.FindEmploymentSchemes.Contentful.csproj
@@ -15,8 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="contentful.csharp" Version="6.0.16" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.31.0.39249">
+    <PackageReference Include="contentful.csharp" Version="6.0.18" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/SFA.DAS.FindEmploymentSchemes.Web.csproj
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/SFA.DAS.FindEmploymentSchemes.Web.csproj
@@ -21,12 +21,12 @@
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.21" />
     <PackageReference Include="AsyncFixer" Version="1.5.1">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.31.0.39249">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
JS packages are up to date
Nuget packages updated as far as possible

Note later versions of 2 packages are available but not currently suitable for use in our projects:
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation later versions do not support .NET Core 3.1
- Contentful.CSharp v7.0.0 has different methods that we cannot use without significant rewriting of code (but this may be possible in future dev phases)