### PR TITLE
Accessibility improvements

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
@@ -70,7 +70,7 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
                             .UnsafeEval()
                             .WithNonce();
 
-                        var styleSrc = builder.AddStyleSrc()
+                        builder.AddStyleSrc()
                             .Self()
                             .From(new[] { cdnUrl, "https://tagmanager.google.com", "https://fonts.googleapis.com"})
                             .StrictDynamic()
@@ -94,8 +94,6 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
                             defaultSrc.From(new[] {"http://localhost:*", "ws://localhost:*"});
 
                             scriptSrc.From("http://localhost:*");
-
-                            styleSrc.UnsafeInline();
 
                             connectSrc.From(new [] { "https://localhost:*", "ws://localhost:*", "wss://localhost:*"});
                         }

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
@@ -73,7 +73,8 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
                         var styleSrc = builder.AddStyleSrc()
                             .Self()
                             .From(new[] { cdnUrl, "https://tagmanager.google.com", "https://fonts.googleapis.com"})
-                            .StrictDynamic();
+                            .StrictDynamic()
+                            .UnsafeInline();
 
                         builder.AddMediaSrc()
                             .None();

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -121,7 +121,7 @@
          </div>
       </header>
       <div id="layout-main-content-container" class="govuk-width-container">
-       <div id="layout-main-content-banner" class="govuk-phase-banner">
+       <div id="layout-main-content-banner" class="govuk-phase-banner" role="region" aria-label="New beta service that supports feedback">
            <p id="layout-main-content-banner-p" class="govuk-phase-banner__content">
                <strong class="govuk-tag govuk-phase-banner__content__tag">
                    beta


### PR DESCRIPTION
### Accessibility Improvements

* the beta service feedback banner has been given an aria role - this _might_ not be optimal, see this [issue](https://github.com/alphagov/govuk-frontend/issues/1604).

### Other Fixes

Allows unsafe inline styles to fix layout issue caused by non-JS GTM iframe.

### Automated Accessibility Test Results

The website has been checked with these accessibility testing tools:
* aXe
* WAVE

The results for each tool are given below.

### aXe

Ran the aXe tool against the site, with these results:

*Homepage*
Issues reported

* 'Elements must have sufficient colour contrast' on [standard crown copyright image](https://trello.com/1/cards/619656303a7ff664c9497e93/attachments/61b20f095c29c525e3e64a58/download/image.png). Image is standard for GDS and non essential for the purpose of the site.

* '"Skip to main content" link is not contained in a landmark. There is a [long discussion on the Drupal site](https://www.drupal.org/project/drupal/issues/3098828) as to why this fails the aXe test, but is actually better for disabled users. It's also standard for GDS, as mentioned in the discussion: "GOV.UK makes excellent use of landmarks, but the skip-link isn't inside a landmark region. By the way, they've used ALL the testing tools."

*Details Page*
Issues reported

* same colour contrast issue as homepage

* same skip link issue as homepage

* breadcrumbs not in landmark. Intentional by GDS, see [here](https://github.com/alphagov/govuk-frontend/issues/1604) and [here](https://github.com/alphagov/static/pull/238).

*Other Pages*
Issues reported

No new issues.

### WAVE
Ran the WAVE (web accessibility evaluation tool) against the website, with these results:

*Homepage*
[Results](https://trello.com/1/cards/619656303a7ff664c9497e93/attachments/61b203441979bf61e860b463/download/homepage.png) 

Result
0 errors
1 false positive alert

* the noscript element used by google analytics - required for GA when Javascript is disabled. It's not being used to provide an accessible version of inaccessible scripted content, so it's not a real issue.

*Details Page*
[Results](https://trello.com/1/cards/619656303a7ff664c9497e93/attachments/61b2043c5784c672729ff1a7/download/image.png) 

Notes
0 errors
1 false positive alert

* the noscript element used by google analytics - see above

*Privacy Notice Page*
[Results](https://trello.com/1/cards/619656303a7ff664c9497e93/attachments/61b204ff71c7ad20fcecb761/download/image.png) 

Notes
0 errors
1 false positive alert

* the noscript element used by google analytics - see above

*Cookies Page*
[Results](https://trello.com/1/cards/619656303a7ff664c9497e93/attachments/61b20570ea12af415f002554/download/image.png) 

Notes
0 errors
2 false positive alert

* the noscript element used by google analytics - see above
* report claims text appears to be a caption for the cookies table, but it is  not

