### PR TITLE
Further accessibility improvements

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/AccessibilityStatement.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/AccessibilityStatement.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "GOV.UK - Accessibility statement";
+    ViewData["Title"] = "Accessibility statement";
 }
 
 @section BreadCrumbs {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/Cookies.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/Cookies.cshtml
@@ -1,8 +1,7 @@
-﻿
-@model SFA.DAS.FindEmploymentSchemes.Web.Models.Page
+﻿@model SFA.DAS.FindEmploymentSchemes.Web.Models.Page
 
 @{
-    ViewData["Title"] = "GOV.UK - Cookies";
+    ViewData["Title"] = "Cookies";
 }
 
 @section BreadCrumbs {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/Page.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Pages/Page.cshtml
@@ -1,7 +1,7 @@
 ﻿@model SFA.DAS.FindEmploymentSchemes.Web.Models.Page
 
 @{
-    ViewData["Title"] = $"GOV.UK - {Model.Title}";
+    ViewData["Title"] = Model.Title.Substring(0, 64);;
 }
 
 @section BreadCrumbs {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Details.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Details.cshtml
@@ -1,7 +1,7 @@
 @model SchemeDetailsModel
 
 @{
-    ViewData["Title"] = $"GOV.UK - {Model.Scheme.Name}";
+    ViewData["Title"] = Model.Scheme.Name.Substring(0, 64);
 }
 
 @section BreadCrumbs {

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
    <head>
       <meta charset="utf-8">
-      <title>@(ViewData["Title"] ?? "GOV.UK - Find training and employment schemes for your business")</title>
+      <title>@(ViewData["Title"] ?? "Find training and employment schemes for your business")</title>
       <meta name="description" content="Government skills training and employment schemes for employers considering hiring or offering placements including Apprenticeships, Traineeships, T Levels.">
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <meta name="theme-color" content="blue">


### PR DESCRIPTION
* remove 'GOV.UK - ' prefix from titles
* limit titles to 64 chars as recommended by w3c