### PR TITLE
Stop the initial flash of the filter box and cookie banner when javascript is enabled

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Schemes/Home.cshtml
@@ -50,7 +50,6 @@
 </div>
 
 <script asp-add-nonce>
-    /*todo: add home.js and include here for js only initialization??*/
     document.addEventListener("DOMContentLoaded", function() {
         $("#close-filter,#filter-box-filter-schemes").click(function(e) {
             $([document.documentElement, document.body]).animate({ scrollTop: $("#scheme-home-filter-outer").offset().top }, 0);

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -8,11 +8,11 @@
       <meta name="theme-color" content="blue">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <script asp-add-nonce>
-      (function (w, d, s, l, i){if(getCookie("DASAcceptCookies")){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
-          var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
-          j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));
-          f.parentNode.insertBefore(j,f);}})(window, document, 'script', 'dataLayer', 'GTM-PLHRMLT');
-      function getCookie(n){const c='; '+document.cookie;const s=c.split('; '+n+'=');if(s.length===2) return s.pop();}
+          (function (w, d, s, l, i){if(getCookie("DASAcceptCookies")){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+              var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
+              j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));
+              f.parentNode.insertBefore(j,f);}})(window, document, 'script', 'dataLayer', 'GTM-PLHRMLT');
+          function getCookie(n){const c='; '+document.cookie;const s=c.split('; '+n+'=');if(s.length===2) return s.pop();}
       </script>
       <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/assets/images/favicon.ico" type="image/x-icon"/>
       <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c"/>
@@ -20,6 +20,14 @@
       <link rel="apple-touch-icon" sizes="167x167" href="/assets/images/govuk-apple-touch-icon-167x167.png"/>
       <link rel="apple-touch-icon" sizes="152x152" href="/assets/images/govuk-apple-touch-icon-152x152.png"/>
       <link rel="apple-touch-icon" href="/assets/images/govuk-apple-touch-icon.png"/>
+      <style asp-add-nonce>.hidden {display:none;}</style>
+      @* waiting until load, delays rendering more than document.addEventListener("DOMContentLoaded"
+          but stops the cookie banner from flashing too
+      *@
+      <script asp-add-nonce>
+          document.documentElement.classList.add("hidden");
+          window.addEventListener("load", function() { document.documentElement.classList.remove("hidden"); });
+      </script>
       <!--[if !IE 8]><!-->
       <link href="/css/main.css" rel="stylesheet"/>
       <link href="/css/site.css" rel="stylesheet" no-cdn />
@@ -27,15 +35,14 @@
       <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
    </head>
    <body id="layout-body" class="govuk-template__body">
+       <script asp-add-nonce>
+           document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+       </script>
 
-      <!-- Google Tag Manager (noscript) -->
+       <!-- Google Tag Manager (noscript) -->
       <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PLHRMLT"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- End Google Tag Manager (noscript) -->
-
-      <script asp-add-nonce>
-          document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-      </script>
 
       <div id="layout-cookie-banner" class="govuk-cookie-banner das-js-show" data-nosnippet role="region" aria-label="Cookies on Find schemes for your business">
          <div id="cookie-message" class="govuk-cookie-banner__message govuk-width-container">


### PR DESCRIPTION
Stop the initial flash of the filter box and cookie banner on page load, when Javascript is enabled.