### PR TITLE
Remove 'change your cookie settings' from cookie confirmation banners

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -64,7 +64,7 @@
               <div id="cookie-accept-column" class="govuk-grid-column-two-thirds">
 
                 <div id="cookie-accept-banner" class="govuk-cookie-banner__content">
-                  <p id="cookie-accept-para" class="govuk-body">You’ve accepted analytics cookies. You can <a id="cookie-accept-link" class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+                  <p id="cookie-accept-para" class="govuk-body">You’ve accepted analytics cookies.</p>
                 </div>
               </div>
             </div>
@@ -81,7 +81,7 @@
               <div id="cookie-reject-column" class="govuk-grid-column-two-thirds">
 
                 <div id="cookie-reject-banner" class="govuk-cookie-banner__content">
-                  <p id="cookie-reject-para" class="govuk-body">You’ve rejected analytics cookies. You can <a id="cookie-reject-link" class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
+                  <p id="cookie-reject-para" class="govuk-body">You’ve rejected analytics cookies.</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Remove 'change your cookie settings' message/link from approve/reject cookie banners.