### PR TITLE
Fix campaign tracking

### DIFF
--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
 
                         var scriptSrc = builder.AddScriptSrc()
                             .Self()
-                            .From(new[] {cdnUrl, "https://tagmanager.google.com"})
+                            .From(new[] {cdnUrl, "https://tagmanager.google.com", "https://www.google-analytics.com/", "https://www.googletagmanager.com" })
                             // this is needed for gtm
                             .UnsafeEval()
                             .UnsafeInline();

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Security/ApplicationBuilderExtensions.cs
@@ -20,7 +20,28 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
         /// https://skillsfundingagency.atlassian.net/wiki/spaces/DAS/pages/3249700873/Adding+Google+Analytics
         ///
         /// Note: we _may_ need the other google domains from the das ga doc,
-        /// but there were no violations reported without them, so we leave them out for now 
+        /// but there were no violations reported without them, so we leave them out for now.
+        ///
+        /// Allowing unsafe-inline scripts
+        /// ------------------------------
+        /// Google's nonce-aware tag manager code has an issue with custom html tags (which we use).
+        /// https://stackoverflow.com/questions/65100704/gtm-not-propagating-nonce-to-custom-html-tags
+        /// https://dev.to/matijamrkaic/using-google-tag-manager-with-a-content-security-policy-9ai
+        ///
+        /// We tried the given solution (above), but the last piece of the puzzle to make it work,
+        /// would involve self hosting a modified version of google's gtm.js script.
+        ///
+        /// In gtm.js, where it's creating customScripts, we'd have to change...
+        /// var n = C.createElement("script");
+        /// to
+        /// var n=C.createElement("script");n.nonce=[get nonce from containing script block];
+        ///
+        /// The problems with self hosting a modified gtm.js are (from https://stackoverflow.com/questions/45615612/is-it-possible-to-host-google-tag-managers-script-locally)
+        /// * we wouldn't automatically pick up any new tags or triggers that Steve added
+        /// * we would need a version of the script that worked across all browsers and versions (and wouldn't have a browser optimised version)
+        /// * we wouldn't pick up new versions of the script
+        /// For these reasons, the only way to get the campaign tracking working, is to open up the CSP to allow unsafe-inline scripts.
+        /// This will make our site less secure, but is a trade-off between security and tracking functionality.
         /// </summary>
         public static IApplicationBuilder UseAppSecurityHeaders(
             this IApplicationBuilder app,
@@ -68,7 +89,8 @@ namespace SFA.DAS.FindEmploymentSchemes.Web.Security
                             .From(new[] {cdnUrl, "https://tagmanager.google.com"})
                             // this is needed for gtm
                             .UnsafeEval()
-                            .WithNonce();
+                            .UnsafeInline();
+                            //.WithNonce();
 
                         builder.AddStyleSrc()
                             .Self()

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/Shared/_Layout.cshtml
@@ -7,7 +7,8 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <meta name="theme-color" content="blue">
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <script asp-add-nonce>
+      @*https://dev.to/matijamrkaic/using-google-tag-manager-with-a-content-security-policy-9ai*@
+      <script id="gtmScript" data-nonce="@Context.GetNonce()" asp-add-nonce>
       (function (w, d, s, l, i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
           var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;
           j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));

--- a/src/SFA.DAS.FindEmploymentSchemes.Web/Views/_ViewImports.cshtml
+++ b/src/SFA.DAS.FindEmploymentSchemes.Web/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
-﻿@using SFA.DAS.FindEmploymentSchemes.Web
+﻿@using NetEscapades.AspNetCore.SecurityHeaders
+@using SFA.DAS.FindEmploymentSchemes.Web
 @using SFA.DAS.FindEmploymentSchemes.Web.Models
 @addTagHelper *, WebOptimizer.Core
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Allow inline scripts to fix campaign tracking.

Also, adds attributes to the GTM script, so that GTM can put the nonce into a variable and use it in custom html scripts (for a potential more secure future fix).
https://dev.to/matijamrkaic/using-google-tag-manager-with-a-content-security-policy-9ai